### PR TITLE
Add helper script and docs for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   - [Requirements](#requirements)
   - [Get Started](#get-started)
   - [Additional Information](#additional-information)
+  - [Running Tests](#running-tests)
 - [⚖️ Ethical and Legal Considerations](#️-ethical-and-legal-considerations)
   - [Disclaimer](#disclaimer)
 
@@ -115,6 +116,15 @@ pip install .
 ai-ops-cli --api AI-OPS_API_ADDRESS
 ```
 
+### Running Tests
+
+To run the unit tests locally you need a running Ollama server and Docker for Qdrant.
+Execute the helper script below which reproduces the CI environment:
+
+```bash
+./scripts/run_tests_with_ollama.sh
+```
+
 ### Additional Information
 
 **User Documentation**
@@ -125,6 +135,8 @@ ai-ops-cli --api AI-OPS_API_ADDRESS
 **Developer Documentation**
 
 1. [Project Structure](./docs/development/1.Project%20Structure.md)
+2. [Agent Architecture Evaluation](./docs/development/2.%20Agent%20Architecture%20Evaluation.md)
+3. [Running Tests](./docs/development/3.Running%20Tests.md)
 
 ---
 

--- a/docs/development/3.Running Tests.md
+++ b/docs/development/3.Running Tests.md
@@ -1,0 +1,9 @@
+# Running Tests
+
+AI-OPS uses a small test suite that depends on a running [Ollama](https://github.com/ollama/ollama) server and a Qdrant instance. The repository provides a helper script to reproduce the CI environment locally.
+
+```bash
+./scripts/run_tests_with_ollama.sh
+```
+
+The script installs the required Python packages, starts Qdrant and Ollama, pulls the models used during testing, and finally executes `pytest`. Set the `ENDPOINT` environment variable if your Ollama instance is listening on a different host or port.

--- a/scripts/run_tests_with_ollama.sh
+++ b/scripts/run_tests_with_ollama.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run AI-OPS unit tests using a local Ollama instance.
+# This script mirrors the CI setup in .github/workflows/unit-test.yml.
+
+# Install python dependencies
+pip install -q -r requirements-api.txt -r requirements-dev.txt
+python -m spacy download en_core_web_md -q
+
+# Environment
+export ENDPOINT="${ENDPOINT:-http://127.0.0.1:11434}"
+export OLLAMA_ENDPOINT="$ENDPOINT"
+export PYTHONPATH="$PYTHONPATH:$(pwd)"
+export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+
+echo "Using ENDPOINT=$ENDPOINT"
+
+docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant &
+qdrant_pid=$!
+
+ollama serve &
+ollama_pid=$!
+
+trap 'kill $qdrant_pid $ollama_pid' EXIT
+
+# wait for Ollama
+for i in {1..10}; do
+    if curl -s -f -o /dev/null "$ENDPOINT/v1/models"; then
+        echo "[+] Ollama is running"
+        break
+    fi
+    echo "[-] Waiting for Ollama to start ..."
+    sleep 5
+done
+
+ollama pull nomic-embed-text
+ollama pull mistral
+
+pytest -q


### PR DESCRIPTION
## Summary
- document how to execute unit tests that rely on Ollama
- provide `run_tests_with_ollama.sh` helper script
- link new documentation and script from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860cf0d6d58832d837ce39056c3b179